### PR TITLE
chore: update version to 1.2.0 and dependencies for Django CMS 4.1+ and Python 3.10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+### Added
+- Update dependencies to support Django CMS 4.1+ and Python 3.10
+
 ## 1.1.8
 ### Fixed
 - fix `'Page' object has no attribute 'is_published'` error on CMS4 projects by replacing CMS3 `page.is_published()` call with a CMS3/CMS4 compatible helper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-search"
-version = "1.1.8"
+version = "1.2.0"
 description = "Provides a nice abstraction layer on top of the django-watson search library."
 authors = [
     "Scott Pashley <scott.pashley@giantdigital.co.uk>",
@@ -12,9 +12,9 @@ license = "MIT"
 homepage = "https://www.giantdigital.co.uk"
 
 [tool.poetry.dependencies]
-python = "^3.7"
-django-cms = ">3.11,<5.0"
-django-watson = "^1.6.3"
+python = ">=3.10"                                                                                                                                                                                     
+django-cms = ">=4.1,<6.0"                                                                                                                                                                             
+django-watson = "^1.6.3" 
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"


### PR DESCRIPTION
Bumps version to allow for CMS5 upgrades