### PR TITLE
Fix NULL search entry URL on django-cms 5.1.1

### DIFF
--- a/giant_search/adapter.py
+++ b/giant_search/adapter.py
@@ -96,7 +96,21 @@ class GiantSearchAdapter(SearchAdapter):
         except AttributeError:
             pass
 
-        return url
+        # watson stores this in a NOT NULL column, and every source above can
+        # legitimately yield None. Page.get_absolute_url() returns None whenever
+        # the page has no PageUrl row yet, which django-cms >= 5.1.1 made the
+        # normal case during page creation: cms.api.create_page_content() now
+        # creates that row *after* PageContent.objects.create() (5.1.0 created it
+        # before), and watson's post_save receiver indexes the content during
+        # that save. 5.1.1 also dropped the get_slug() fallback that used to
+        # paper over it. Without this coercion, creating any page raises
+        # `IntegrityError: NOT NULL constraint failed: watson_searchentry.url`.
+        #
+        # "" is the right value rather than a guess at the eventual URL: there is
+        # nowhere for a user to go yet, and SearchResultProcessor already drops
+        # url="" entries, so such content stays out of results until something
+        # re-indexes it with a real URL.
+        return url or ""
 
     def serialize_meta(self, obj):
         """


### PR DESCRIPTION
## Problem

On django-cms 5.1.1, creating **any** page raises:

```
django.db.utils.IntegrityError: NOT NULL constraint failed: watson_searchentry.url
  cms/api.py:394        create_page_content()
  watson/search.py:541  _post_save_receiver → update_obj_index
```

This takes out page creation in the admin entirely for any site running `giant-search` with `PageContent` registered for search. It surfaced as a crash-looping deploy on the giant-cms demo, where the nightly re-lock picked up 5.1.1 unattended.

## Cause

`GiantSearchAdapter.get_url()` returns whatever `get_absolute_url()` gives it, unguarded. `Page.get_absolute_url()` returns `None` when the page has no `PageUrl` row — and 5.1.1 made that the normal state during page creation.

`cms.api.create_page_content()` now creates the `PageUrl` row **after** `PageContent.objects.create()`, where 5.1.0 created it before:

```python
page_content = PageContent.objects.with_user(user).create(...)   # watson post_save fires HERE
page_content.rescan_placeholders()

if page_content.is_public():
    page.urls.update_or_create(...)                              # PageUrl created only now
```

watson's `post_save` receiver runs *during* that `create()`, when no `PageUrl` exists. 5.1.1 also removed the `get_slug()` fallback that previously masked this:

```python
-  path = self.get_path(language, fallback) or self.get_slug(language, fallback)
+  path = self.get_path(language, fallback)          # None — no PageUrl row
   return reverse(...) if path else None             # returns None
```

`SearchEntry.url` is `NOT NULL`, so the insert fails.

Worth noting: this is **not** versioning-specific. The `is_public()` gate makes it permanent for draft content, but the reordering alone is enough — it reproduces with djangocms-versioning absent.

## Fix

Coerce the result to `""`. `""` rather than a guess at the eventual URL because there is nowhere for a user to go yet, and `SearchResultProcessor.exclude_items_without_url()` already drops `url=""` entries, so such content stays out of results until something re-indexes it with a real URL.

## Verification

Bisected against a minimal django-cms project that registers `PageContent` via `register_for_search` and calls `create_page()`:

| django-cms | adapter | result |
| --- | --- | --- |
| 5.1.0 | unpatched | ✅ `SearchEntry.url='/home/'` |
| 5.1.1 | unpatched | ❌ `IntegrityError: NOT NULL constraint failed` |
| 5.1.1 | patched | ✅ `SearchEntry.url=''` |

I did not add a regression test to the suite: `tests/` does not currently run on django-cms 4/5 at all. `tests/test_settings.py` omits `django.contrib.admin` (so `cms.signals` fails to import with `RuntimeError: Model class django.contrib.admin.models.LogEntry doesn't declare an explicit app_label`), `tests/models.py` imports `PlaceholderField`, and `tests.py` calls the CMS3-era `page.publish()`. Rehabilitating that harness is worth doing but is a bigger change than this fix, and I did not want to bundle the two.

## Follow-up

On 5.1.1 a newly created page is indexed with `url=""`, so it stays out of search results until re-indexed. Whether publishing re-saves `PageContent` (and so re-indexes with the real URL) needs confirming — if it does not, page URLs will need a `buildwatson` or an explicit re-index hook on publish. That is a separate concern from this crash.